### PR TITLE
Adding small change to allow for built-in MapQueue objects

### DIFF
--- a/MapGen.pm
+++ b/MapGen.pm
@@ -64,6 +64,7 @@ sub _check_opts {
             next if $k eq "objs";
             next if $k eq "_the_map";
             next if $k eq "_the_groups";
+            next if $k eq "_the_queue";
 
             push @e, "unrecognized option: '$k'";
         }


### PR DESCRIPTION
This is just an extra object in the "allowed" list to allow for maps with built-in MapQueue objects.
